### PR TITLE
Fix/get correct test results ztest

### DIFF
--- a/.github/scripts/run_tests.py
+++ b/.github/scripts/run_tests.py
@@ -109,19 +109,19 @@ if __name__ == "__main__":
 
         # Unit tests for local libs (no device needed)
         if args.target and "app/unit/host" in args.target:
-            cmd_test = "west twister -vv"
+            cmd_test = "west twister -vv --force-clean"
         # Robot tests
         elif args.target and "app/robot" in args.target:
             cmd_test = "pabot"
         # Only integration tests for specific platfom(s)
         elif args.integration_tests and args.integration_tests == "yes" and args.device_serial and args.device_serial != "":
-            cmd_test = f"west twister -vv --platform {args.platform} --device-testing --device-serial {args.device_serial} --tag integration --west-flash --flash-before"
+            cmd_test = f"west twister -vv --platform {args.platform} --force-clean --device-testing --device-serial {args.device_serial} --tag integration --flash-before"
         # Only integration tests for all platforms
         elif args.integration_tests and args.integration_tests == "yes" and args.device_serial and args.device_serial == "":
-            cmd_test = f"west twister -vv --platform {args.platform} --tag integration"
+            cmd_test = f"west twister -vv --platform {args.platform} --force-clean --tag integration"
         # All other tests (device HW needed)
         else:
-            cmd_test = f"west twister -vv --platform {args.platform} --device-testing --device-serial {args.device_serial} --west-flash --flash-before"
+            cmd_test = f"west twister -vv --platform {args.platform} --force-clean --device-testing --device-serial {args.device_serial} --flash-before"
 
         for line in tests:
             out, err, code = run_cmd(f'{cmd_test} {line.replace("\n", "")}{arguments}')

--- a/.github/scripts/run_tests.py
+++ b/.github/scripts/run_tests.py
@@ -109,19 +109,19 @@ if __name__ == "__main__":
 
         # Unit tests for local libs (no device needed)
         if args.target and "app/unit/host" in args.target:
-            cmd_test = "west twister -vv --force-clean"
+            cmd_test = "west twister -vv"
         # Robot tests
         elif args.target and "app/robot" in args.target:
             cmd_test = "pabot"
         # Only integration tests for specific platfom(s)
         elif args.integration_tests and args.integration_tests == "yes" and args.device_serial and args.device_serial != "":
-            cmd_test = f"west twister -vv --platform {args.platform} --force-clean --device-testing --device-serial {args.device_serial} --tag integration --flash-before"
+            cmd_test = f"west twister -vv --platform {args.platform} --device-testing --device-serial {args.device_serial} --tag integration --flash-before"
         # Only integration tests for all platforms
         elif args.integration_tests and args.integration_tests == "yes" and args.device_serial and args.device_serial == "":
-            cmd_test = f"west twister -vv --platform {args.platform} --force-clean --tag integration"
+            cmd_test = f"west twister -vv --platform {args.platform} --tag integration"
         # All other tests (device HW needed)
         else:
-            cmd_test = f"west twister -vv --platform {args.platform} --force-clean --device-testing --device-serial {args.device_serial} --flash-before"
+            cmd_test = f"west twister -vv --platform {args.platform} --device-testing --device-serial {args.device_serial} --flash-before"
 
         for line in tests:
             out, err, code = run_cmd(f'{cmd_test} {line.replace("\n", "")}{arguments}')

--- a/tests/repo_tests/gpio_toggle_ztest/src/main.c
+++ b/tests/repo_tests/gpio_toggle_ztest/src/main.c
@@ -47,8 +47,16 @@ bool contains_false(bool *list, int size) {
     return false;  // All values are true
 }
 
+/* Time delay for Ztest testcase to grab test START correctly*/
+static bool ts_setup(const void *data)
+{
+    k_busy_wait(500000); // 500ms delay to stabilize serial
+    return true;
+}
 
-ZTEST(gpio, test_gpio_toggle_and_verify)
+ZTEST_SUITE(gpio, ts_setup, NULL, NULL, NULL, NULL);
+
+Z_ZTEST(gpio, test_gpio_toggle_and_verify, 0)
 {
     zassert_true(gpio_is_ready_dt(&led), "GPIO device not ready");
     printk("GPIO system is ready\n");
@@ -100,5 +108,3 @@ ZTEST(gpio, test_gpio_toggle_and_verify)
 
     zassert_true(contains_false(list, size), "GPIO (LED) state mismatch, test failed");
 }
-
-ZTEST_SUITE(gpio, NULL, NULL, NULL, NULL, NULL);

--- a/tests/repo_tests/gpio_toggle_ztest/testcase.yaml
+++ b/tests/repo_tests/gpio_toggle_ztest/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  repo_tests.gpio_toggle_ztest:
+  repo_tests.dut.gpio_toggle_ztest:
     platform_allow:
       - esp32s3_devkitc/esp32s3/procpu
       - esp32c3_devkitm

--- a/tests/unit_tests/dut/gpio_pins_ztest/src/main.c
+++ b/tests/unit_tests/dut/gpio_pins_ztest/src/main.c
@@ -8,6 +8,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/ztest.h>
 
+
 #if DT_NODE_HAS_PROP(DT_ALIAS(led0), gpios)
 #define TEST_NODE DT_GPIO_CTLR(DT_ALIAS(led0), gpios)
 #define TEST_PIN DT_GPIO_PIN(DT_ALIAS(led0), gpios)
@@ -15,8 +16,16 @@
 #error Unsupported board
 #endif
 
+/* Time delay for Ztest testcase to grab test START correctly*/
+static bool ts_setup(const void *data)
+{
+    k_busy_wait(500000); // 500ms delay to stabilize serial
+    return true;
+}
 
-ZTEST(gpio_pins_ztest, test_gpio_manipulation)
+ZTEST_SUITE(pins, ts_setup, NULL, NULL, NULL, NULL);
+
+Z_ZTEST(pins, test_gpio_manipulation, 0)
 {
 	int response;
 	const struct device *port;
@@ -42,5 +51,3 @@ ZTEST(gpio_pins_ztest, test_gpio_manipulation)
 	response = gpio_pin_get(port, TEST_PIN);
 	zassert_equal(response, 0, "Invalid pin state: %d", response);
 }
-
-ZTEST_SUITE(gpio_pins_ztest, NULL, NULL, NULL, NULL, NULL);

--- a/tests/unit_tests/dut/gpio_pins_ztest/testcase.yaml
+++ b/tests/unit_tests/dut/gpio_pins_ztest/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
-  unit_tests.dut.gpio_pins_ztest:
+  unit_tests.dut.gpio_pins:
     tags:
     - drivers
     - gpio


### PR DESCRIPTION
Added workaround for Ztest test cases for on-device HW testing. This resolves the issue to get test suite START info for correct identification all test cases.
1. Added 500ms delay before Ztest test suite starts.
2. Z_ZTEST() macro is used instead of ZTEST().