### PR TITLE
Feat/add manual simulation tests

### DIFF
--- a/tests/manual_tests/esp32_toggle_led_qemu/CMakeLists.txt
+++ b/tests/manual_tests/esp32_toggle_led_qemu/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+cmake_minimum_required(VERSION 3.20.0)
+
+set(DTC_OVERLAY_FILE "boards/esp32s3_devkitc.overlay")
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(blinky)
+
+target_sources(app PRIVATE src/main.c)

--- a/tests/manual_tests/esp32_toggle_led_qemu/README.md
+++ b/tests/manual_tests/esp32_toggle_led_qemu/README.md
@@ -1,0 +1,94 @@
+## Toggle LED test for ESP32 boards with QEMU simulation
+### Description
+This test script is designed to verify the functionality of toggling an LED on an ESP32 board using QEMU simulation. 
+No target board is required for this test. The test script will run on Host machine with Espressif QEMU installed.
+The test script will toggle the LED on the virtual board what is represented by teminal messages "LED state: OFF: and "LED state: OFF". The LED is toggled every 1 second. The test script will run in 10 cycles and then must be interrupted by manual intervention - see <strong>Usage</strong> section for more details.
+
+<br/>
+
+### Prerequisites
+- Espressif QEMU package installed on Host.
+
+<br/>
+
+#### Usage
+
+- Build the sample binaries into the output folder `build/`:<br/>
+
+   ```
+   west build -p always -b esp32s3_devkitc/esp32s3/procpu tests/manual_tests/esp32_toggle_led_qemu
+   ```
+
+- Run the simulation:
+
+   ```
+   qemu-system-xtensa -nographic -machine esp32s3 -drive file=build/zephyr/zephyr_4mb.bin,if=mtd,format=raw
+   ```
+
+- Check the output on terminal, it should be:
+
+   ```
+   *** Booting Zephyr OS build v4.2.0-3707-g49157ea8fc71 ***
+   Test cycle: 1
+   LED state: OFF
+   Test cycle: 2
+   LED state: ON
+   Test cycle: 3
+   LED state: OFF
+   ...
+   ```
+
+- Stop the QEMU simulation running on background:
+
+   ```
+   ps aux | grep qemu-system-xtensa
+   kill <PID>
+   ```
+
+<br/>   
+
+#### Installation of Espressif QEMU
+
+For list of supported features in Espressif QEMU see the documentation on <a href="documentation/Tests_user_guide.md">https://github.com/espressif/esp-toolchain-docs/blob/main/qemu/README.md</a>.
+
+1. Download Espressif QEMU installation package by wget tool from <a href="https://github.com/espressif/qemu/releases/">https://github.com/espressif/qemu/releases/</a>.
+
+   ```
+   cd ~/Downloads
+   wget -O qemu-xtensa-softmmu-esp_develop_9.2.2_20250817-aarch64-linux-gnu.tar.xz https://github.com/espressif/qemu/releases/download/esp-develop-9.2.2-20250817/qemu-xtensa-softmmu-esp_develop_9.2.2_20250817-aarch64-linux-gnu.tar.xz
+   ```
+
+2. Extract the package to a directory of your choice.
+
+   ```
+   tar -xf qemu-xtensa-softmmu-esp_develop_9.2.2_20250817-aarch64-linux-gnu.tar.xz
+   ```
+
+3. Choose a directory of your choice to install Espressif QEMU.
+
+   ```
+   mkdir -p /home/<USER>/espressif-qemu/
+   mv ~/Downloads/qemu/* /home/<USER>/espressif-qemu/
+   ```
+
+4. Export new environment variable for QEMU binaries.
+
+   ```
+   export PATH="/home/<USER>/espressif-qemu/bin:$PATH"
+   ```
+
+5. Then, build the application:
+
+   ```
+   cd customer-application
+   west build -p always -b esp32s3_devkitc/esp32s3/procpu tests/manual_tests/esp32_toggle_led_qemu
+   ```
+
+6. Next, create a 4 MB binary from your compiled binary file and pad the end with zeros.
+
+   ```
+   dd if=/dev/zero of=build/zephyr/zephyr_4mb.bin bs=1M count=4
+   dd if=build/zephyr/zephyr.bin of=build/zephyr/zephyr_4mb.bin conv=notrunc
+   ```
+
+7. Finally you can run the application in QEMU (see <strong>Usage</strong> section for more details).

--- a/tests/manual_tests/esp32_toggle_led_qemu/boards/esp32s3_devkitc.overlay
+++ b/tests/manual_tests/esp32_toggle_led_qemu/boards/esp32s3_devkitc.overlay
@@ -1,0 +1,12 @@
+/ {
+     aliases {
+             led0 = &myled0;
+     };
+
+     leds {
+             compatible = "gpio-leds";
+             myled0: led_0 {
+                     gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+             };
+     };
+};

--- a/tests/manual_tests/esp32_toggle_led_qemu/prj.conf
+++ b/tests/manual_tests/esp32_toggle_led_qemu/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_GPIO=y

--- a/tests/manual_tests/esp32_toggle_led_qemu/sample.yaml
+++ b/tests/manual_tests/esp32_toggle_led_qemu/sample.yaml
@@ -1,0 +1,12 @@
+sample:
+  name: Espressif QEMU test
+tests:
+  sample.basic.blinky:
+    platform_allow:
+      - qemu
+    tags:
+      - LED
+      - gpio
+    filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds")
+    depends_on: gpio
+    harness: led

--- a/tests/manual_tests/esp32_toggle_led_qemu/src/main.c
+++ b/tests/manual_tests/esp32_toggle_led_qemu/src/main.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+
+/* 1000 msec = 1 sec */
+#define SLEEP_TIME_MS   1000
+
+/* The devicetree node identifier for the "led0" alias. */
+#define LED0_NODE DT_ALIAS(led0)
+
+/*
+ * A build error on this line means your board is unsupported.
+ * See the sample documentation for information on how to fix this.
+ */
+static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(LED0_NODE, gpios);
+
+int main(void)
+{
+	int ret;
+	bool led_state = true;
+
+	if (!gpio_is_ready_dt(&led)) {
+		return 0;
+	}
+
+	ret = gpio_pin_configure_dt(&led, GPIO_OUTPUT_ACTIVE);
+	if (ret < 0) {
+		return 0;
+	}
+
+	for (int i = 0; i < 10; i++) {
+		ret = gpio_pin_toggle_dt(&led);
+		if (ret < 0) {
+			return 0;
+		}
+
+		led_state = !led_state;
+		printf("Test cycle: %d\n", i);
+		printf("LED state: %s\n", led_state ? "ON" : "OFF");
+		k_msleep(SLEEP_TIME_MS);
+	}
+	return 0;
+}

--- a/tests/repo_tests/mock_adc/CMakeLists.txt
+++ b/tests/repo_tests/mock_adc/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.20.0)
+set(DTC_OVERLAY_FILE "boards/native_sim.overlay")
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(mock_adc_sample)
+
+target_sources(app PRIVATE src/main.c)
+target_sources(app PRIVATE drivers/adc/mock_adc.c)

--- a/tests/repo_tests/mock_adc/boards/native_sim.overlay
+++ b/tests/repo_tests/mock_adc/boards/native_sim.overlay
@@ -1,0 +1,8 @@
+/ {
+    mock_adc0: mock_adc@0 {
+        compatible = "zephyr,mock-adc";
+        status = "okay";
+        label = "MOCK_ADC";
+        reg = <0x0 0x1000>;  // address = 0x0, size = 0x1000
+    };
+};

--- a/tests/repo_tests/mock_adc/drivers/adc/mock_adc.c
+++ b/tests/repo_tests/mock_adc/drivers/adc/mock_adc.c
@@ -1,0 +1,31 @@
+#include <zephyr/device.h>
+#include <zephyr/drivers/adc.h>
+#include <zephyr/init.h>
+
+#define DT_DRV_COMPAT zephyr_mock_adc
+
+static int mock_adc_channel_setup(const struct device *dev, const struct adc_channel_cfg *cfg) {
+    return 0;
+}
+
+static int mock_adc_read(const struct device *dev, const struct adc_sequence *sequence) {
+    if (sequence->buffer_size >= sizeof(uint16_t)) {
+        ((uint16_t *)sequence->buffer)[0] = 1234;
+        return 0;
+    }
+    return -ENOMEM;
+}
+
+static const struct adc_driver_api mock_adc_api __used = {
+    .channel_setup = mock_adc_channel_setup,
+    .read = mock_adc_read,
+};
+
+static int mock_adc_init(const struct device *dev) {
+    return 0;
+}
+
+DEVICE_DT_DEFINE(DT_NODELABEL(mock_adc0), mock_adc_init, NULL, NULL, NULL,
+                 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+                 &mock_adc_api);
+

--- a/tests/repo_tests/mock_adc/prj.conf
+++ b/tests/repo_tests/mock_adc/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ADC=y

--- a/tests/repo_tests/mock_adc/sample.yaml
+++ b/tests/repo_tests/mock_adc/sample.yaml
@@ -1,0 +1,10 @@
+tests:
+  repo_tests.adc.mocking:
+    tags: adc
+    platform_allow:
+      - native_sim/native/64
+    harness: console    
+    harness_config:
+      type: one_line
+      regex: 
+        - "ADC read value: .*"

--- a/tests/repo_tests/mock_adc/src/main.c
+++ b/tests/repo_tests/mock_adc/src/main.c
@@ -1,0 +1,44 @@
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/adc.h>
+#include <zephyr/sys/printk.h>
+
+
+#define ADC_RESOLUTION 12
+#define ADC_CHANNEL_ID 0
+
+int main(void) {
+    // const struct device *adc_dev = DEVICE_DT_INST_GET(0);
+    const struct device *adc_dev = DEVICE_DT_GET(DT_NODELABEL(mock_adc0));
+
+    if (!device_is_ready(adc_dev)) {
+        printk("ADC device not ready\n");
+        return 1;
+    }
+
+    struct adc_channel_cfg channel_cfg = {
+        .gain = ADC_GAIN_1,
+        .reference = ADC_REF_INTERNAL,
+        .acquisition_time = ADC_ACQ_TIME_DEFAULT,
+        .channel_id = ADC_CHANNEL_ID,
+    };
+
+    adc_channel_setup(adc_dev, &channel_cfg);
+
+    uint16_t sample_buffer;
+    struct adc_sequence sequence = {
+        .channels = BIT(ADC_CHANNEL_ID),
+        .buffer = &sample_buffer,
+        .buffer_size = sizeof(sample_buffer),
+        .resolution = ADC_RESOLUTION,
+    };
+
+    if (adc_read(adc_dev, &sequence) == 0) {
+        printk("ADC read value: %d\n", sample_buffer);
+        k_sleep(K_SECONDS(5));
+
+    } else {
+        printk("ADC read failed\n");
+    }
+    return 0;
+}


### PR DESCRIPTION
Added:
1. Simulation tests with native_sim with mocking the ADC temperature converter (automated test).
2. Simulation QEMU test for Espressif boards with Toggle LED sample (manual test).